### PR TITLE
docs(api): fix fileId type

### DIFF
--- a/doc/paying-api.yml
+++ b/doc/paying-api.yml
@@ -1016,4 +1016,4 @@ components:
         - $ref: '#/components/schemas/CreateAttachment'
       properties:
         fileId:
-          type: String
+          type: string


### PR DESCRIPTION
codegen generates `ModelString` instead of `string` for `fileId` in `bpartners-react-client` because of its type in swagger specs