### PR TITLE
chore: change rest attachment to File

### DIFF
--- a/doc/paying-api.yml
+++ b/doc/paying-api.yml
@@ -1052,7 +1052,7 @@ components:
           type: string
         content:
           type: string
-          format: byte
+          format: binary
     Attachment:
       allOf:
         - $ref: '#/components/schemas/CreateAttachment'

--- a/src/main/java/app/bpartners/api/endpoint/rest/mapper/AttachmentRestMapper.java
+++ b/src/main/java/app/bpartners/api/endpoint/rest/mapper/AttachmentRestMapper.java
@@ -2,14 +2,18 @@ package app.bpartners.api.endpoint.rest.mapper;
 
 import app.bpartners.api.endpoint.rest.model.Attachment;
 import app.bpartners.api.endpoint.rest.model.CreateAttachment;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import static app.bpartners.api.service.utils.FileUtils.toByteArray;
+
 @Component
+@Slf4j
 public class AttachmentRestMapper {
   public app.bpartners.api.model.Attachment toDomain(CreateAttachment createAttachment) {
     return app.bpartners.api.model.Attachment.builder()
         .name(createAttachment.getName())
-        .content(createAttachment.getContent())
+        .content(toByteArray(createAttachment.getContent()))
         .build();
   }
 

--- a/src/main/java/app/bpartners/api/service/utils/FileUtils.java
+++ b/src/main/java/app/bpartners/api/service/utils/FileUtils.java
@@ -1,6 +1,13 @@
 package app.bpartners.api.service.utils;
 
+import app.bpartners.api.model.exception.ApiException;
+import app.bpartners.api.model.exception.BadRequestException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Base64;
+
+import static app.bpartners.api.model.exception.ApiException.ExceptionType.CLIENT_EXCEPTION;
 
 public class FileUtils {
   private FileUtils() {
@@ -11,5 +18,20 @@ public class FileUtils {
       return null;
     }
     return Base64.getEncoder().encodeToString(image);
+  }
+
+  public static byte[] toByteArray(File file) {
+    try (FileInputStream fileInputStream = new FileInputStream(file);) {
+      int fileSize = (int) file.length();
+      byte[] result = new byte[fileSize];
+      int readBytes = fileInputStream.read(result);
+      if (fileSize != readBytes) {
+        throw new ApiException(CLIENT_EXCEPTION, "File"
+            + file.getName() + " could not be entirely read. ");
+      }
+      return result;
+    } catch (IOException e) {
+      throw new BadRequestException(e.getMessage());
+    }
   }
 }

--- a/src/test/java/app/bpartners/api/integration/InvoiceRelaunchIT.java
+++ b/src/test/java/app/bpartners/api/integration/InvoiceRelaunchIT.java
@@ -181,7 +181,7 @@ class InvoiceRelaunchIT {
     Resource pngFile = new ClassPathResource("files/png-file.png");
     return new CreateAttachment()
         .name("attachment1")
-        .content(pngFile.getInputStream().readAllBytes());
+        .content(pngFile.getFile());
   }
 
   Attachment expectedAttachment() throws IOException {


### PR DESCRIPTION
Actual API converts TypeScript base64 to byte array.

This PR shows us an alternative where API converts TypeScript arrayBuffer to byte array.

Which one is better ?