### PR TITLE
chore: move prospect creation with existing email validation on a dedicated endpoint

### DIFF
--- a/doc/prospecting-api.yml
+++ b/doc/prospecting-api.yml
@@ -133,6 +133,44 @@ operations:
           $ref: './api.yml#/components/responses/429'
         500:
           $ref: './api.yml#/components/responses/500'
+    post:
+      tags:
+        - Prospecting
+      summary: update prospects of an accountHolder with existing email validation.
+      operationId: updateProspectsWithEmailCheck
+      parameters:
+        - in: path
+          name: ahId
+          schema:
+            type: string
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/UpdateProspect'
+      responses:
+        200:
+          description: List of updated prospects.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Prospect'
+        400:
+          $ref: './api.yml#/components/responses/400'
+        403:
+          $ref: './api.yml#/components/responses/403'
+        404:
+          $ref: './api.yml#/components/responses/404'
+        429:
+          $ref: './api.yml#/components/responses/429'
+        500:
+          $ref: './api.yml#/components/responses/500'
     put:
       tags:
         - Prospecting

--- a/src/main/java/app/bpartners/api/endpoint/rest/controller/ProspectController.java
+++ b/src/main/java/app/bpartners/api/endpoint/rest/controller/ProspectController.java
@@ -162,6 +162,14 @@ public class ProspectController {
         .toList();
   }
 
+  @PostMapping("/accountHolders/{ahId}/prospects")
+  public List<Prospect> crupdateProspectsWithEmailCheck(
+      @PathVariable("ahId") String accountHolderId, @RequestBody List<UpdateProspect> prospects) {
+    List<app.bpartners.api.model.prospect.Prospect> prospectList =
+        prospects.stream().map(prospect -> mapper.toDomain(accountHolderId, prospect)).toList();
+    return service.saveAllWithEmailCheck(prospectList).stream().map(mapper::toRest).toList();
+  }
+
   @PutMapping("/accountHolders/{ahId}/prospects")
   public List<Prospect> crupdateProspects(
       @PathVariable("ahId") String accountHolderId, @RequestBody List<UpdateProspect> prospects) {

--- a/src/main/java/app/bpartners/api/service/prospect/ProspectRepositoryService.java
+++ b/src/main/java/app/bpartners/api/service/prospect/ProspectRepositoryService.java
@@ -1,0 +1,39 @@
+package app.bpartners.api.service.prospect;
+
+import app.bpartners.api.endpoint.event.EventProducer;
+import app.bpartners.api.endpoint.event.model.ProspectUpdated;
+import app.bpartners.api.model.prospect.Prospect;
+import app.bpartners.api.repository.ProspectRepository;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProspectRepositoryService {
+  private final ProspectRepository repository;
+  private final EventProducer eventProducer;
+
+  public List<Prospect> saveAll(List<Prospect> toSave) {
+    var savedProspects = repository.saveAll(toSave);
+
+    savedProspects.forEach(
+        savedProspect -> {
+          var optionalProspect =
+              toSave.stream()
+                  .filter(
+                      prospect -> savedProspect.getEmail().equalsIgnoreCase(prospect.getEmail()))
+                  .findFirst();
+          eventProducer.accept(
+              List.of(
+                  ProspectUpdated.builder()
+                      .prospect(savedProspect)
+                      .isNew(optionalProspect.map(Prospect::isNew).orElse(false))
+                      .updatedAt(Instant.now())
+                      .build()));
+        });
+
+    return savedProspects;
+  }
+}

--- a/src/main/java/app/bpartners/api/service/prospect/ProspectService.java
+++ b/src/main/java/app/bpartners/api/service/prospect/ProspectService.java
@@ -97,6 +97,7 @@ public class ProspectService {
   private final CustomDateFormatter customDateFormatter;
   private final ProspectJpaRepository prospectJpaRepository;
   private final UserWhiteListedJpaRepository userWhiteListedJpaRepository;
+  private final ProspectRepositoryService prospectRepositoryService;
 
   private static List<ProspectResult> ratedCustomers(
       List<ProspectResult> prospectResults, Double minRating) {
@@ -289,30 +290,12 @@ public class ProspectService {
       throw new BadRequestException(exceptionBuilder.toString());
     }
 
-    return saveAll(prospects);
+    return prospectRepositoryService.saveAll(prospects);
   }
 
   @Transactional
   public List<Prospect> saveAll(List<Prospect> toSave) {
-    var savedProspects = repository.saveAll(toSave);
-
-    savedProspects.forEach(
-        savedProspect -> {
-          var optionalProspect =
-              toSave.stream()
-                  .filter(
-                      prospect -> savedProspect.getEmail().equalsIgnoreCase(prospect.getEmail()))
-                  .findFirst();
-          eventProducer.accept(
-              List.of(
-                  ProspectUpdated.builder()
-                      .prospect(savedProspect)
-                      .isNew(optionalProspect.map(Prospect::isNew).orElse(false))
-                      .updatedAt(Instant.now())
-                      .build()));
-        });
-
-    return savedProspects;
+    return prospectRepositoryService.saveAll(toSave);
   }
 
   private List<Prospect> handleProspectToSave(

--- a/src/main/java/app/bpartners/api/service/prospect/ProspectService.java
+++ b/src/main/java/app/bpartners/api/service/prospect/ProspectService.java
@@ -282,18 +282,24 @@ public class ProspectService {
   }
 
   @Transactional
-  public List<Prospect> saveAll(List<Prospect> toSave) {
+  public List<Prospect> saveAllWithEmailCheck(List<Prospect> toSave) {
     StringBuilder exceptionBuilder = new StringBuilder();
     var prospects = handleProspectToSave(toSave, exceptionBuilder);
     if (!exceptionBuilder.isEmpty()) {
       throw new BadRequestException(exceptionBuilder.toString());
     }
+
+    return saveAll(prospects);
+  }
+
+  @Transactional
+  public List<Prospect> saveAll(List<Prospect> toSave) {
     var savedProspects = repository.saveAll(toSave);
 
     savedProspects.forEach(
         savedProspect -> {
           var optionalProspect =
-              prospects.stream()
+              toSave.stream()
                   .filter(
                       prospect -> savedProspect.getEmail().equalsIgnoreCase(prospect.getEmail()))
                   .findFirst();

--- a/src/test/java/app/bpartners/api/endpoint/rest/controller/ProspectControllerTest.java
+++ b/src/test/java/app/bpartners/api/endpoint/rest/controller/ProspectControllerTest.java
@@ -29,6 +29,7 @@ import app.bpartners.api.service.SnsService;
 import app.bpartners.api.service.aws.SesService;
 import app.bpartners.api.service.customer.CustomerService;
 import app.bpartners.api.service.dataprocesser.ProspectDataProcesser;
+import app.bpartners.api.service.prospect.ProspectRepositoryService;
 import app.bpartners.api.service.prospect.ProspectService;
 import app.bpartners.api.service.prospect.ProspectStatusService;
 import app.bpartners.api.service.user.UserService;
@@ -66,6 +67,8 @@ class ProspectControllerTest {
       new ExtendedProspectUpdateValidator();
   ProspectRestMapper prospectRestMapper =
       new ProspectRestMapper(prospectRestValidator, extendedProspectUpdateValidator);
+  ProspectRepositoryService prospectRepositoryService =
+      new ProspectRepositoryService(prospectRepository, eventProducerMock);
 
   ProspectService prospectService =
       new ProspectService(
@@ -86,7 +89,8 @@ class ProspectControllerTest {
           templateResolverEngine,
           customDateFormatter,
           prospectJpaRepositoryMock,
-          userWhiteListedJpaRepositoryMock);
+          userWhiteListedJpaRepositoryMock,
+          prospectRepositoryService);
 
   ProspectController subject =
       new ProspectController(

--- a/src/test/java/app/bpartners/api/endpoint/rest/controller/ProspectControllerTest.java
+++ b/src/test/java/app/bpartners/api/endpoint/rest/controller/ProspectControllerTest.java
@@ -1,0 +1,161 @@
+package app.bpartners.api.endpoint.rest.controller;
+
+import static java.util.UUID.randomUUID;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import app.bpartners.api.endpoint.event.EventProducer;
+import app.bpartners.api.endpoint.event.SesConf;
+import app.bpartners.api.endpoint.event.model.ProspectUpdated;
+import app.bpartners.api.endpoint.rest.mapper.ProspectJobRestMapper;
+import app.bpartners.api.endpoint.rest.mapper.ProspectRestMapper;
+import app.bpartners.api.endpoint.rest.model.ProspectStatus;
+import app.bpartners.api.endpoint.rest.model.UpdateProspect;
+import app.bpartners.api.endpoint.rest.validator.ExtendedProspectUpdateValidator;
+import app.bpartners.api.endpoint.rest.validator.ProspectRestValidator;
+import app.bpartners.api.model.UserWhiteListed;
+import app.bpartners.api.model.exception.BadRequestException;
+import app.bpartners.api.model.mapper.ProspectMapper;
+import app.bpartners.api.repository.ProspectEvaluationJobRepository;
+import app.bpartners.api.repository.ProspectRepository;
+import app.bpartners.api.repository.expressif.utils.ProspectEvalUtils;
+import app.bpartners.api.repository.google.calendar.CalendarApi;
+import app.bpartners.api.repository.google.sheets.SheetApi;
+import app.bpartners.api.repository.jpa.AccountHolderJpaRepository;
+import app.bpartners.api.repository.jpa.ProspectJpaRepository;
+import app.bpartners.api.repository.jpa.UserWhiteListedJpaRepository;
+import app.bpartners.api.repository.jpa.model.HProspect;
+import app.bpartners.api.service.SnsService;
+import app.bpartners.api.service.aws.SesService;
+import app.bpartners.api.service.customer.CustomerService;
+import app.bpartners.api.service.dataprocesser.ProspectDataProcesser;
+import app.bpartners.api.service.prospect.ProspectService;
+import app.bpartners.api.service.prospect.ProspectStatusService;
+import app.bpartners.api.service.user.UserService;
+import app.bpartners.api.service.utils.CustomDateFormatter;
+import app.bpartners.api.service.utils.TemplateResolverEngine;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ProspectControllerTest {
+  EventProducer eventProducerMock = mock();
+  ProspectJobRestMapper prospectJobRestMapper = mock();
+  ProspectEvalUtils prospectEvalUtilsMock = mock();
+  ProspectRepository prospectRepository = mock();
+  ProspectDataProcesser prospectDataProcesser = mock();
+  AccountHolderJpaRepository accountHolderJpaRepository = mock();
+  SesService sesService = mock();
+  CustomerService customerService = mock();
+  SheetApi sheetApi = mock();
+  ProspectMapper prospectMapper = mock();
+  ProspectEvaluationJobRepository prospectEvaluationJobRepository = mock();
+  SesConf sesConf = mock();
+  ProspectStatusService prospectStatusService = mock();
+  SnsService snsService = mock();
+  UserService userService = mock();
+  CalendarApi calendarApi = mock();
+  TemplateResolverEngine templateResolverEngine = mock();
+  CustomDateFormatter customDateFormatter = mock();
+  UserWhiteListedJpaRepository userWhiteListedJpaRepositoryMock = mock();
+  ProspectJpaRepository prospectJpaRepositoryMock = mock();
+
+  ProspectRestValidator prospectRestValidator = new ProspectRestValidator();
+  ExtendedProspectUpdateValidator extendedProspectUpdateValidator =
+      new ExtendedProspectUpdateValidator();
+  ProspectRestMapper prospectRestMapper =
+      new ProspectRestMapper(prospectRestValidator, extendedProspectUpdateValidator);
+
+  ProspectService prospectService =
+      new ProspectService(
+          prospectRepository,
+          prospectDataProcesser,
+          accountHolderJpaRepository,
+          sesService,
+          customerService,
+          sheetApi,
+          prospectMapper,
+          prospectEvaluationJobRepository,
+          eventProducerMock,
+          sesConf,
+          prospectStatusService,
+          snsService,
+          userService,
+          calendarApi,
+          templateResolverEngine,
+          customDateFormatter,
+          prospectJpaRepositoryMock,
+          userWhiteListedJpaRepositoryMock);
+
+  ProspectController subject =
+      new ProspectController(
+          prospectService,
+          prospectRestMapper,
+          prospectEvalUtilsMock,
+          prospectRestValidator,
+          prospectJobRestMapper,
+          eventProducerMock);
+
+  @Test
+  void exception_when_saving_existing_prospect_on_crupdateProspectsWithEmailCheck() {
+    var prospects = List.of(new UpdateProspect().email("old@email.com"));
+    var accountHolderId = "accountHolderId";
+
+    when(userWhiteListedJpaRepositoryMock.findByIdAccountHolder(anyString()))
+        .thenReturn(Optional.of(userWhiteListed()));
+    when(prospectJpaRepositoryMock.findByOldEmailOrNewEmailAndIdAccountHolder(
+            anyString(), anyString(), anyString()))
+        .thenReturn(List.of(hProspect()));
+
+    assertThrows(
+        BadRequestException.class,
+        () -> subject.crupdateProspectsWithEmailCheck(accountHolderId, prospects));
+  }
+
+  @Test
+  void save_not_existing_prospects_and_triggers_events() {
+    var accountHolderId = "accountHolderId";
+    var emailOne = randomUUID().toString();
+    var emailTwo = randomUUID().toString();
+    var updates =
+        List.of(
+            new UpdateProspect().id(emailOne).email(emailOne).status(ProspectStatus.TO_CONTACT),
+            new UpdateProspect().id(emailTwo).email(emailTwo).status(ProspectStatus.TO_CONTACT));
+
+    when(userWhiteListedJpaRepositoryMock.findByIdAccountHolder(any()))
+        .thenReturn(Optional.empty());
+    when(prospectJpaRepositoryMock.findByOldEmailOrNewEmailAndIdAccountHolder(any(), any(), any()))
+        .thenReturn(List.of());
+    when(prospectRepository.saveAll(anyList()))
+        .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+
+    var actual = subject.crupdateProspectsWithEmailCheck(accountHolderId, updates);
+
+    var eventCaptor = ArgumentCaptor.forClass(List.class);
+    verify(eventProducerMock, times(2)).accept(eventCaptor.capture());
+    var allEvents = eventCaptor.getAllValues();
+    var firstEvent = (ProspectUpdated) allEvents.getFirst().getFirst();
+    var secondEvent = (ProspectUpdated) allEvents.getLast().getFirst();
+
+    assertEquals(2, actual.size());
+    assertEquals(emailOne, actual.get(0).getEmail());
+    assertEquals(emailTwo, actual.get(1).getEmail());
+    assertTrue(firstEvent.isNew());
+    assertTrue(secondEvent.isNew());
+  }
+
+  UserWhiteListed userWhiteListed() {
+    return new UserWhiteListed().toBuilder().id("existingUserId").build();
+  }
+
+  HProspect hProspect() {
+    return new HProspect()
+        .toBuilder()
+            .id("existingProspectId")
+            .oldEmail("old@email.com")
+            .newEmail("new@email.com")
+            .idAccountHolder("accountHolderOwnerId")
+            .build();
+  }
+}

--- a/src/test/java/app/bpartners/api/unit/service/ProspectServiceTest.java
+++ b/src/test/java/app/bpartners/api/unit/service/ProspectServiceTest.java
@@ -44,6 +44,7 @@ import app.bpartners.api.service.SnsService;
 import app.bpartners.api.service.aws.SesService;
 import app.bpartners.api.service.customer.CustomerService;
 import app.bpartners.api.service.dataprocesser.ProspectDataProcesser;
+import app.bpartners.api.service.prospect.ProspectRepositoryService;
 import app.bpartners.api.service.prospect.ProspectService;
 import app.bpartners.api.service.prospect.ProspectStatusService;
 import app.bpartners.api.service.user.UserService;
@@ -82,6 +83,9 @@ class ProspectServiceTest {
   CalendarApi calendarApiMock = mock(CalendarApi.class);
   ProspectJpaRepository prospectJpaRepositoryMock = mock(ProspectJpaRepository.class);
   UserWhiteListedJpaRepository userWhiteListedJpaRepositoryMock = mock();
+
+  ProspectRepositoryService prospectRepositoryService =
+      new ProspectRepositoryService(repositoryMock, eventProducerMock);
   ProspectService subject =
       new ProspectService(
           repositoryMock,
@@ -101,7 +105,8 @@ class ProspectServiceTest {
           mock(),
           new CustomDateFormatter(),
           prospectJpaRepositoryMock,
-          userWhiteListedJpaRepositoryMock);
+          userWhiteListedJpaRepositoryMock,
+          prospectRepositoryService);
 
   @BeforeEach
   void setup() {

--- a/src/test/java/app/bpartners/api/unit/service/ProspectServiceTest.java
+++ b/src/test/java/app/bpartners/api/unit/service/ProspectServiceTest.java
@@ -159,7 +159,7 @@ class ProspectServiceTest {
     when(repositoryMock.saveAll(anyList()))
         .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
-    var actual = subject.saveAll(toSave);
+    var actual = subject.saveAllWithEmailCheck(toSave);
 
     var eventCaptor = ArgumentCaptor.forClass(List.class);
     verify(eventProducerMock, times(2)).accept(eventCaptor.capture());
@@ -204,7 +204,8 @@ class ProspectServiceTest {
             eq(prospectOneEmail), eq(prospectOneEmail), any()))
         .thenReturn(List.of(persistedProspect));
 
-    var actualException = assertThrows(BadRequestException.class, () -> subject.saveAll(toSave));
+    var actualException =
+        assertThrows(BadRequestException.class, () -> subject.saveAllWithEmailCheck(toSave));
 
     verify(eventProducerMock, never()).accept(any());
     assertEquals(
@@ -248,7 +249,7 @@ class ProspectServiceTest {
     when(repositoryMock.saveAll(anyList()))
         .thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
 
-    var actual = subject.saveAll(toSave);
+    var actual = subject.saveAllWithEmailCheck(toSave);
 
     var eventCaptor = ArgumentCaptor.forClass(List.class);
     verify(eventProducerMock, times(2)).accept(eventCaptor.capture());


### PR DESCRIPTION
Created POST /accountHolders/{ahId}/prospects